### PR TITLE
[MountManager] Fix newline bug in Change hostname

### DIFF
--- a/networkbrowser/src/MountManager.py
+++ b/networkbrowser/src/MountManager.py
@@ -134,14 +134,14 @@ class AutoMountManager(Screen):
 	def hostEdit(self):
 		if os_path.exists("/etc/hostname"):
 			fp = open('/etc/hostname', 'r')
-			self.hostname = fp.read()
+			self.hostname = fp.read().rstrip('\n')
 			fp.close()
 			self.session.openWithCallback(self.hostnameCallback, VirtualKeyBoard, title = (_("Enter new hostname for your Receiver")), text = self.hostname)
 
 	def hostnameCallback(self, callback = None):
 		if callback is not None and len(callback):
 			fp = open('/etc/hostname', 'w+')
-			fp.write(callback)
+			fp.write(callback + '\n')
 			fp.flush()
 			fsync(fp.fileno())
 			fp.close()


### PR DESCRIPTION
In MountManager.hostEdit() the newline in /etc/hostname isn't stripped
before passing the hostname to the VirtualKeyBoard for editing.

This commit strips any trailing newlines from the ends of the
read hostname and adds a newline when the new hostname is written.